### PR TITLE
Safely start service

### DIFF
--- a/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -46,8 +46,22 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
     @Override
     public void initialize() {
         Log.d(LOGTAG, "Native module init");
-        startFcmIntentService(FcmInstanceIdRefreshHandlerService.EXTRA_IS_APP_INIT);
-
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            ActivityManager activityManager = (ActivityManager) getReactApplicationContext().getApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
+            if (activityManager != null) {
+                List<ActivityManager.RunningAppProcessInfo> runningAppProcesses = activityManager.getRunningAppProcesses();
+                if (runningAppProcesses != null && runningAppProcesses.size() > 0) {
+                    int importance = runningAppProcesses.get(0).importance;
+                    if (importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
+                        startFcmIntentService(FcmInstanceIdRefreshHandlerService.EXTRA_IS_APP_INIT);
+                    }
+                }
+            } else {
+                startFcmIntentService(FcmInstanceIdRefreshHandlerService.EXTRA_IS_APP_INIT);
+            }
+        } else {
+            startFcmIntentService(FcmInstanceIdRefreshHandlerService.EXTRA_IS_APP_INIT);
+        }
         final IPushNotificationsDrawer notificationsDrawer = PushNotificationsDrawer.get(getReactApplicationContext().getApplicationContext());
         notificationsDrawer.onAppInit();
     }


### PR DESCRIPTION
Android has an OS-level issue where if we start a service in the background it throws an IllegalStateException. The Android team said they will have it fixed in the following releases.

The main goal of this service is to listen for PushNotification Token. I believe that if we don't start the service in the event that the app is not in the foreground, it isn't going to cause any issue. It also shouldn't cause the user to miss any notifications as tokens don't change frequently.

More details can be found in the following two sites:
https://issuetracker.google.com/issues/110237673

https://stackoverflow.com/questions/52013545/android-9-0-not-allowed-to-start-service-app-is-in-background-after-onresume