### PR TITLE
Check if react-native is initialized

### DIFF
--- a/android/app/src/main/java/com/wix/reactnativenotifications/core/JsIOHelper.java
+++ b/android/app/src/main/java/com/wix/reactnativenotifications/core/JsIOHelper.java
@@ -17,7 +17,7 @@ public class JsIOHelper {
     }
 
     public boolean sendEventToJS(String eventName, WritableMap data, ReactContext reactContext) {
-        if (reactContext != null) {
+        if (reactContext != null && reactContext.hasActiveCatalystInstance()) {
             reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName, data);
             return true;
         }

--- a/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -63,7 +63,11 @@ public class PushNotification implements IPushNotification {
     @Override
     public void onReceived() throws InvalidNotificationException {
         postNotification(null);
-        notifyReceivedToJS();
+        if (mAppLifecycleFacade.isReactInitialized()) {
+            notifyReceivedToJS();
+        } else {
+            setAsInitialNotification();
+        }
         if (mAppLifecycleFacade.isAppVisible()) {
             notifiyReceivedForegroundNotificationToJS();
         }


### PR DESCRIPTION
Check if react-native is initialized prior to sending any events over the bridge.

This will fix the following issue:
https://app.bugsnag.com/hurdlr-inc/hurdlr-react-native/errors/5de71fe33580e9001a8b47d9?filters[event.since][0][type]=eq&filters[event.since][0][value]=all&filters[error.status][0][type]=eq&filters[error.status][0][value]=open&filters[app.release_stage][0][value]=PROD&filters[app.release_stage][0][type]=eq&filters[app.release_stage][1][value]=production&filters[app.release_stage][1][type]=eq